### PR TITLE
Calculate avg std based on transit trips

### DIFF
--- a/APC/SF_CMP_Transit_APC_Speed_Revenue vs Stop Distance.py
+++ b/APC/SF_CMP_Transit_APC_Speed_Revenue vs Stop Distance.py
@@ -439,7 +439,7 @@ def match_intermediate_apc_stops(apc_pairs, apc_cmp, timep):
     apc_pairs_clean = apc_pairs[apc_pairs['cur_stop_dwell_time']<180]
     apc_trip_speeds = apc_pairs_clean.groupby(['cmp_segid', 'trip_id', 'trip_date']).agg({'cur_next_loc_dis': 'sum',
                                                                        'cur_next_rev_dis': 'sum',
-                                                                        'cur_next_time': 'sum').reset_index()
+                                                                        'cur_next_time': 'sum'}).reset_index()
     apc_trip_speeds.columns = ['cmp_segid', 'trip_id', 'trip_date', 
                               'trip_stop_distance', 'trip_rev_distance', 'trip_traveltime']
     apc_trip_speeds['trip_loc_speed'] = 3600* apc_trip_speeds['trip_stop_distance']/apc_trip_speeds['trip_traveltime']

--- a/APC/SF_CMP_Transit_APC_Speed_Revenue vs Stop Distance.py
+++ b/APC/SF_CMP_Transit_APC_Speed_Revenue vs Stop Distance.py
@@ -442,10 +442,10 @@ def match_intermediate_apc_stops(apc_pairs, apc_cmp, timep):
                                                                         'cur_next_time': 'sum').reset_index()
     apc_trip_speeds.columns = ['cmp_segid', 'trip_id', 'trip_date', 
                               'trip_stop_distance', 'trip_rev_distance', 'trip_traveltime']
-    apc_trip_speeds['trip_loc_speed'] = 3600* apc_cmp_speeds['trip_stop_distance']/apc_cmp_speeds['trip_traveltime']
-    apc_trip_speeds['trip_rev_speed'] = 3600* apc_cmp_speeds['trip_rev_distance']/apc_cmp_speeds['trip_traveltime']
+    apc_trip_speeds['trip_loc_speed'] = 3600* apc_trip_speeds['trip_stop_distance']/apc_trip_speeds['trip_traveltime']
+    apc_trip_speeds['trip_rev_speed'] = 3600* apc_trip_speeds['trip_rev_distance']/apc_trip_speeds['trip_traveltime']
     
-    apc_cmp_speeds = apc_pairs_clean.groupby(['cmp_segid']).agg({'trip_stop_distance': 'sum',
+    apc_cmp_speeds = apc_trip_speeds.groupby(['cmp_segid']).agg({'trip_stop_distance': 'sum',
                                                                        'trip_rev_distance': 'sum',
                                                                         'trip_traveltime': 'sum',
                                                                        'trip_loc_speed': 'std',

--- a/APC/SF_CMP_Transit_APC_Speed_Revenue vs Stop Distance.py
+++ b/APC/SF_CMP_Transit_APC_Speed_Revenue vs Stop Distance.py
@@ -44,6 +44,12 @@ cmp_segs_prj['cmp_name'] = cmp_segs_prj['cmp_name'].str.lower()
 cmp_segs_prj['Length'] = cmp_segs_prj.geometry.length 
 cmp_segs_prj['Length'] = cmp_segs_prj['Length'] * 3.2808  #meters to feet
 
+# INRIX network
+inrix_net=gp.read_file(os.path.join(NETCONF_DIR, 'inrix_xd_sf.shp'))
+inrix_net['RoadName'] = inrix_net['RoadName'].str.lower()
+
+cmp_inrix_corr = pd.read_csv(os.path.join(NETCONF_DIR, 'CMP_Segment_INRIX_Links_Correspondence.csv'))
+
 # Create a buffer zone for each cmp segment
 ft=160   # According to the memo from last CMP cycle
 mt=round(ft/3.2808,4)


### PR DESCRIPTION
The major update is aggregating transit pairs to trips based on trip_id and trip_date. Another important update is to remove mismatched transit stops found during QAQC.